### PR TITLE
Ticket1481 Corruption of user name entry

### DIFF
--- a/asubFunctionsApp/src/copyArgA.c
+++ b/asubFunctionsApp/src/copyArgA.c
@@ -30,12 +30,12 @@ static long copyArgA(aSubRecord *prec)
          errlogPrintf("%s incorrect input type. ", prec->name);
 		 return -1;
 	}
+    
 	memset(str_out, '\0', prec->nova); /* pad with NULL */
-    for(n=0; n<prec->noa && n<prec->nova; ++n)
+    for(n=0; n<prec->noa && n<prec->nea; ++n)
     {
         str_out[n] = str_in[n];
     }
-    prec->neva = (prec->nea < n ? prec->nea : n);
     return 0; /* process output links */
 }
 

--- a/asubFunctionsApp/src/copyArgA.c
+++ b/asubFunctionsApp/src/copyArgA.c
@@ -1,12 +1,8 @@
 /** @file copyArgA.c
- *  @author Freddie Akeroyd, STFC (freddie.akeroyd@stfc.ac.uk)
  *  @ingroup asub_functions
  *
- *  Copy a CHAR waveform record into a STRING waveform record. If this is done by
- *  a normal CAPUT the character byte codes are not preserved
- *
  *  It expect the A input to be the waveform data and B to be "NORD" (number of elements)
- *  it write its output to VALA
+ *  it set the output length to be one more than the input to ensure NULL termination on copy
  */
 #include <string.h>
 #include <registryFunction.h>
@@ -16,7 +12,7 @@
 
 #include <epicsExport.h>
 /**
- *  Convert a character waveform into a string waveform
+ *  Copy a character waveform
  *  @ingroup asub_functions
  *  @param[in] prec Pointer to aSub record
  */
@@ -27,16 +23,15 @@ static long copyArgA(aSubRecord *prec)
 	char* str_out = (char*)(prec->vala); /* waveform CHAR data */
     if (prec->fta != menuFtypeCHAR || prec->fta != prec->ftva)
 	{
-         errlogPrintf("%s incorrect input type. ", prec->name);
+         errlogPrintf("%s incorrect input type - must be CHAR. ", prec->name);
 		 return -1;
 	}
-    
-	memset(str_out, '\0', prec->nova); /* pad with NULL */
+	memset(str_out, '\0', prec->nova); /* initialise output with NULL */
     for(n=0; n<prec->nea && n<prec->noa && n<prec->nova; ++n)
     {
         str_out[n] = str_in[n];
     }
-    prec->neva = (n+1 < prec->nova ? n+1 : prec->nova);
+    prec->neva = (n+1 < prec->nova ? n+1 : prec->nova); /* +1 ensures a NULL terminator is copied to the next record */
     return 0; /* process output links */
 }
 

--- a/asubFunctionsApp/src/copyArgA.c
+++ b/asubFunctionsApp/src/copyArgA.c
@@ -32,10 +32,11 @@ static long copyArgA(aSubRecord *prec)
 	}
     
 	memset(str_out, '\0', prec->nova); /* pad with NULL */
-    for(n=0; n<prec->noa && n<prec->nea; ++n)
+    for(n=0; n<prec->nea && n<prec->noa && n<prec->nova; ++n)
     {
         str_out[n] = str_in[n];
     }
+    prec->neva = (n+1 < prec->nova ? n+1 : prec->nova);
     return 0; /* process output links */
 }
 


### PR DESCRIPTION
This asub routine is for copying a new value from str_in into str_out which is then sent to a database record. The output record is first padded to its maximum length with zeros, then copies in the value from str_in. Problem was that str_in does not clear in between, so that artefacts would remain at the end if newer values were shorter than older ones.
Changed the code so that str_in is only copied up to the length of the current value (nea) rather than the entire length of str_in.

To test:
https://github.com/ISISComputingGroup/IBEX/issues/1481
One of the uses of this subroutine is updating usernames in the DAE:
1. Monitor (P):DAE:_USERNAMES
2. Add users to experiment setup
3. Modify users so that the string of their names is shorter than before
4. Check the value in the above PV is correct (surnames of all users separated by commas) with no extra letters at the end.
